### PR TITLE
feat: configurable auditd configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -362,6 +362,7 @@ debian9cis_warning_banner: |
 # End Banner
 
 ## Section 4 Vars
+debian9cis_install_auditd: true
 debian9cis_auditd:
   admin_space_left_action: halt
   max_log_file_action: keep_logs

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -35,6 +35,8 @@
     name: "{{ auditd_package[ansible_os_family] }}"
     state: present
     install_recommends: false
+  when:
+    - debian9cis_install_auditd
 
 - name: "PRELIM | Section 5.1 | Configure cron"
   apt:

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -6,6 +6,7 @@
       line: "max_log_file = 10"
       state: present
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_1_1
   notify:
       - restart auditd
@@ -23,6 +24,7 @@
       line: "admin_space_left_action = {{ debian9cis_auditd['admin_space_left_action'] }}"
       state: present
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_1_2
   notify:
       - restart auditd
@@ -40,6 +42,7 @@
       line: "space_left_action = email"
       state: present
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_1_2
   notify:
       - restart auditd
@@ -57,6 +60,7 @@
       line: "max_log_file_action = {{ debian9cis_auditd['max_log_file_action'] }}"
       state: present
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_1_3
   notify:
       - restart auditd
@@ -74,6 +78,7 @@
       enabled: true
   when:
       - not debian9cis_skip_for_travis
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_2
   tags:
       - level2
@@ -92,6 +97,7 @@
   notify:
       - generate new grub config
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_3
   tags:
       - level2
@@ -108,6 +114,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_4
   notify:
       - load audit rules
@@ -127,6 +134,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_5
   notify:
       - load audit rules
@@ -146,6 +154,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_6
   notify:
       - load audit rules
@@ -165,6 +174,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_7
   notify:
       - load audit rules
@@ -184,6 +194,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_8
   notify:
       - load audit rules
@@ -203,6 +214,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_9
   notify:
       - load audit rules
@@ -222,6 +234,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_10
   notify:
       - load audit rules
@@ -241,6 +254,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_11
   notify:
       - load audit rules
@@ -272,6 +286,7 @@
             - load audit rules
             - restart auditd
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_12
   tags:
       - level2
@@ -288,6 +303,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_13
   notify:
       - load audit rules
@@ -307,6 +323,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_14
   notify:
       - load audit rules
@@ -326,6 +343,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_15
   notify:
       - load audit rules
@@ -345,6 +363,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_16
   notify:
       - load audit rules
@@ -364,6 +383,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_17
   notify:
       - load audit rules
@@ -383,6 +403,7 @@
       group: root
       mode: 0600
   when:
+      - debian9cis_install_auditd
       - debian9cis_rule_4_1_18
   notify:
       - load audit rules


### PR DESCRIPTION
It might not be required if using another audit tool (e.g auditbeat).